### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ sign = ecc.sign(data, privateKey)
 
 本协议由SouthEX起草，MeetOne、More、TokenPocket、KKWallet、HaloWallet 共同参与讨论和修改。
 
-除以上五家钱包之外，目前正在接入的钱包商还包括：EOS Live钱包、番茄钱包。
+除以上五家钱包之外，目前正在接入的钱包商还包括：EOS LIVE钱包、番茄钱包。
 
 目前接入此协议的名单：https://github.com/southex/SimpleWallet/blob/master/supporter_list.md
 

--- a/supporter_list.md
+++ b/supporter_list.md
@@ -16,7 +16,7 @@ https://docs.google.com/forms/d/e/1FAIpQLSciEsvqsbale3-zcmktBB62_RzaNlKRtBHY1pVt
 - KKWallet
 - Tokenpocket
 - HaloWallet
-- EOSLive
+- EOS LIVE
 - 番茄钱包
 
 ## exchange


### PR DESCRIPTION
Fix typo, our wallet named EOS LIVE.